### PR TITLE
re #15887: Improve feedback to user about verification.

### DIFF
--- a/ok_tools/settings.py
+++ b/ok_tools/settings.py
@@ -85,8 +85,9 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
-            BASE_DIR/'registration/templates',
-            BASE_DIR/'licenses/templates',
+            BASE_DIR/'licenses'/'templates',
+            BASE_DIR/'ok_tools'/'templates',
+            BASE_DIR/'registration'/'templates',
         ],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/ok_tools/templates/home.html
+++ b/ok_tools/templates/home.html
@@ -7,6 +7,22 @@
 {% block content %}
 {% if user.is_authenticated %}
   <p>Hi {{ user.email }}!</p>
+
+  {% if not user.profile.verified %}
+  <p>
+    {% blocktranslate %}
+    This account is not verified. Please print the application form, sign it and send it back to us. The account will then be verified.
+    {% endblocktranslate %}
+  <p>
+    <a class="btn btn-outline-primary" href="{% url 'registration:print_registration' %}">
+    {%translate 'Application form'%}</a>
+  <p>
+  </p>
+  {% else %}
+    {% blocktranslate %}
+    This account is verified.
+    {% endblocktranslate %}
+  {% endif %}
   <p><a class="btn btn-outline-primary" href="{% url 'logout' %}">{%translate 'Log Out'%}</a><p>
   <p><a class="btn btn-outline-primary" href="{% url 'password_reset' %}">{%translate 'Change Password'%}</a></p>
 {% else %}

--- a/ok_tools/templates/home.html
+++ b/ok_tools/templates/home.html
@@ -11,7 +11,7 @@
   {% if not user.profile.verified %}
   <p>
     {% blocktranslate %}
-    This account is not verified. Please print the application form, sign it and send it back to us. The account will then be verified.
+    This account is not verified. Please print the application form, sign it and bring it with your personal ID back to us. The account will then be verified.
     {% endblocktranslate %}
   <p>
     <a class="btn btn-outline-primary" href="{% url 'registration:print_registration' %}">

--- a/ok_tools/urls.py
+++ b/ok_tools/urls.py
@@ -28,10 +28,12 @@ urlpatterns = [
         PasswordResetConfirmView.as_view(),
         name="password_reset_confirm",
     ),
-    path('profile/password_reset/',
-         PasswordResetView.as_view(),
-         name='password_reset'
-         ),
+    path(
+        'profile/password_reset/',
+        PasswordResetView.as_view(),
+        name='password_reset'
+    ),
+    # This includes upstream passsword reset, login/out views.
     path('profile/', include('django.contrib.auth.urls')),
     path('admin/', admin.site.urls),
     path('licenses/', include('licenses.urls')),

--- a/ok_tools/views_tests.py
+++ b/ok_tools/views_tests.py
@@ -8,7 +8,6 @@ def test_views__home__1(browser, user):
 
 def test_views__home__2(browser, user):
     """It shows a message if the account is not verified."""
-    browser.handleErrors = False
     browser.login()
     assert (
         'This account is not verified. Please print the application form, sign'

--- a/ok_tools/views_tests.py
+++ b/ok_tools/views_tests.py
@@ -1,0 +1,28 @@
+def test_views__home__1(browser, user):
+    """It welcomes the user and allows a password change."""
+    browser.login()
+    assert f'Hi {user.email}!' in browser.contents
+    browser.follow('Change password')
+    assert 'password_reset' in browser.url
+
+
+def test_views__home__2(browser, user):
+    """It shows a message if the account is not verified."""
+    browser.handleErrors = False
+    browser.login()
+    assert (
+        'This account is not verified. Please print the application form, sign'
+        ' it and send it back to us. The account will then be verified.'
+        in browser.contents
+    )
+    browser.follow('Application form')
+    assert 'profile/application' in browser.url
+
+
+def test_views__home__3(browser, user):
+    """It shows no message if the account is verified."""
+    user.profile.verified = True
+    user.profile.save()
+    browser.login()
+    assert 'This account is not verified.' not in browser.contents
+    assert 'This account is verified.' in browser.contents

--- a/registration/admin_tests.py
+++ b/registration/admin_tests.py
@@ -89,25 +89,6 @@ def test__registration__signals__verify_profile__1(db, user, browser):
     assert testuser.has_perm(VERIFIED_PERM)
 
 
-def test__registration__signals__verify_profile__1_05(
-        db, user, browser, mail_outbox):
-    """After verification a user gets send an email."""
-    assert 0 == len(mail_outbox)
-    browser.login_admin()
-    browser.getLink('Profiles').click()
-    browser.getLink(user.email).click()
-    browser.getControl('Verified').selected = True
-    browser.getControl(name='_save').click()
-
-    assert 1 == len(mail_outbox)
-    assert 'has been verified' in mail_outbox[-1].subject
-    assert (
-        'We have received your application and verified your data. Your'
-        ' account is now fully activated.' in mail_outbox[-1].body
-    )
-    assert user.profile.first_name in mail_outbox[-1].body
-
-
 def test__registration__signals__verify_profile__2(db, user_dict):
     """A User created as verified has the permission 'verified'."""
     user = create_user(user_dict, verified=True)
@@ -129,6 +110,25 @@ def test__registration__signals__verify_profile__3(db, user, browser):
 
     testuser = User.objects.get(email=user.email)
     assert not testuser.has_perm(VERIFIED_PERM)
+
+
+def test__registration__signals__send_verification_mail__1(
+        db, user, browser, mail_outbox):
+    """After verification a user gets send an email."""
+    assert 0 == len(mail_outbox)
+    browser.login_admin()
+    browser.getLink('Profiles').click()
+    browser.getLink(user.email).click()
+    browser.getControl('Verified').selected = True
+    browser.getControl(name='_save').click()
+
+    assert 1 == len(mail_outbox)
+    assert 'has been verified' in mail_outbox[-1].subject
+    assert (
+        'We have received your application and verified your data. Your'
+        ' account is now fully activated.' in mail_outbox[-1].body
+    )
+    assert user.profile.first_name in mail_outbox[-1].body
 
 
 def test__registration__signals___get_permission__1(db):

--- a/registration/admin_tests.py
+++ b/registration/admin_tests.py
@@ -94,7 +94,6 @@ def test__registration__signals__verify_profile__1_05(
     """After verification a user gets send an email."""
     assert 0 == len(mail_outbox)
     browser.login_admin()
-    browser.handleErrors = False
     browser.getLink('Profiles').click()
     browser.getLink(user.email).click()
     browser.getControl('Verified').selected = True

--- a/registration/email.py
+++ b/registration/email.py
@@ -7,6 +7,7 @@ from django.db.models import Q
 from django.template import loader
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+from typing import Any
 import logging
 
 
@@ -14,13 +15,13 @@ logger = logging.getLogger('django')
 UserModel = get_user_model()
 
 
-def _send_auth_mail(
-    subject_template_name,
-    email_template_name,
-    context,
-    from_email,
-    to_email,
-):
+def send_mail(
+    subject_template_name: str,
+    email_template_name: str,
+    context: dict[str, Any],
+    from_email: str,
+    to_email: str,
+) -> None:
     """
     Send a django.core.mail.EmailMultiAlternatives to `to_email`.
 
@@ -80,7 +81,7 @@ def send_auth_mail(
         "protocol": protocol,
         **(extra_email_context or {}),
     }
-    _send_auth_mail(
+    send_mail(
         subject_template_name,
         email_template_name,
         context,

--- a/registration/registration_tests.py
+++ b/registration/registration_tests.py
@@ -216,7 +216,7 @@ def test__registration__backends__EmailBackend__3(browser):
     assert 'enter a correct email address and password' in browser.contents
 
 
-def test__registration__signals__is_validated__1(db, user):
+def test__registration__signals__verify_profile__1(db, user):
     """Users with unverified profile don't have the permission 'verified'."""
     assert not user.has_perm('registration.verified')
 

--- a/registration/signals.py
+++ b/registration/signals.py
@@ -18,7 +18,7 @@ profile_verified = Signal()
 
 @receiver(post_save, sender=Profile)
 def verify_profile(sender, instance, update_fields, **kwargs):
-    """If a profile is verified it sets permission and sends an email."""
+    """If a profile is verified it sets permission."""
     if ((update_fields and 'verified' in update_fields) or
             kwargs.get('created')):
         user = instance.okuser

--- a/registration/signals.py
+++ b/registration/signals.py
@@ -5,11 +5,15 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_save
+from django.dispatch import Signal
 from django.dispatch import receiver
 import logging
 
 
 logger = logging.getLogger('django')
+
+
+profile_verified = Signal()
 
 
 @receiver(post_save, sender=Profile)
@@ -22,19 +26,25 @@ def verify_profile(sender, instance, update_fields, **kwargs):
 
         if instance.verified:
             user.user_permissions.add(verified_permission)
-            send_mail(
-                email_template_name='email/confirm_verification_body.html',
-                subject_template_name='email/confirm_verification_subject.txt',
-                context={
-                    "first_name": instance.first_name,
-                    "ok_name": settings.OK_NAME,
-                    "domain": 'localhost:8000',
-                },
-                from_email=settings.EMAIL_HOST_USER,
-                to_email=user.email,
-            )
         else:
             user.user_permissions.remove(verified_permission)
+
+
+@receiver(profile_verified)
+def send_verification_mail(sender, obj=None, request=None, **kwargs):
+    """Send the mail, if the profile was verified."""
+    if obj.verified:
+        send_mail(
+            email_template_name='email/confirm_verification_body.html',
+            subject_template_name='email/confirm_verification_subject.txt',
+            context={
+                "first_name": obj.first_name,
+                "ok_name": settings.OK_NAME,
+                "domain": request.get_host(),
+            },
+            from_email=settings.EMAIL_HOST_USER,
+            to_email=obj.okuser.email,
+        )
 
 
 @receiver(post_save, sender=get_user_model())

--- a/registration/templates/email/confirm_verification_body.html
+++ b/registration/templates/email/confirm_verification_body.html
@@ -1,0 +1,24 @@
+{% load i18n %}
+
+{% blocktranslate %}
+Hello {{ first_name }},
+{% endblocktranslate %}
+
+{% blocktranslate %}
+We have received your application and verified your data. Your account is now fully activated.
+{% endblocktranslate %}
+
+{% blocktranslate %}
+You can now login and file a license request.
+{% endblocktranslate %}
+
+
+{% block login_link %}
+https://{{ domain }}{% url 'home' %}
+{% endblock %}
+
+{% blocktranslate %}
+Have a great day,
+
+The {{ ok_name }} team
+{% endblocktranslate %}

--- a/registration/templates/email/confirm_verification_subject.txt
+++ b/registration/templates/email/confirm_verification_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% blocktranslate %}
+Your Account for {{ ok_name }} has been verified
+{% endblocktranslate %}


### PR DESCRIPTION
Show a message after login, that the application has to be sent. Also send an email after verification by staff in the admin UI.

https://projects.gocept.com/issues/15887

Testanleitung:
* Bei eine unverifiziertem Profil wird nach dem Login ein Hinweis auf den ausstehenden Antrag angezeigt.
* Nach der Verifizierung wird ein Erfolg vermeldet.
* Nach der Verifizierung wird eine Email versendet. 
** Dies funktioniert sowohl aus der Profil-Einzelansicht, als auch aus dem ListView.