### PR TITLE
reduce warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,13 +1,13 @@
 from contributions.models import DisaImport
 from datetime import datetime
 from datetime import timedelta
-from django.conf import settings
 from django.core import mail
 from django.urls import reverse_lazy
 from licenses.models import default_category
 from ok_tools.testing import DOMAIN
 from ok_tools.testing import EMAIL
 from ok_tools.testing import PWD
+from ok_tools.testing import TZ
 from ok_tools.testing import create_contribution
 from ok_tools.testing import create_disaimport
 from ok_tools.testing import create_license_request
@@ -17,7 +17,6 @@ from projects.models import Project
 from projects.models import ProjectLeader
 from projects.models import default_category as default_project_category
 from projects.models import default_target_group
-from zoneinfo import ZoneInfo
 import ok_tools.wsgi
 import pytest
 import zope.testbrowser.browser
@@ -125,7 +124,7 @@ def contribution_dict() -> dict:
                                    month=8,
                                    day=25,
                                    hour=12,
-                                   tzinfo=ZoneInfo(settings.TIME_ZONE)
+                                   tzinfo=TZ,
                                    ),
         'live': False,
     }
@@ -153,8 +152,8 @@ def project_dict() -> dict:
         'title': 'title',
         'topic': 'topic',
         'duration': timedelta(hours=1, minutes=30),
-        'begin_date': datetime(year=2022, month=9, day=20, hour=9),
-        'end_date': datetime(year=2022, month=9, day=20, hour=10),
+        'begin_date': datetime(year=2022, month=9, day=20, hour=9, tzinfo=TZ),
+        'end_date': datetime(year=2022, month=9, day=20, hour=10, tzinfo=TZ),
         'external_venue': False,
         'jugendmedienschutz': False,
         'target_group': default_target_group(),

--- a/contributions/contributions_tests.py
+++ b/contributions/contributions_tests.py
@@ -6,7 +6,6 @@ from .disa_import import validate
 from .models import Contribution
 from .models import DisaImport
 from datetime import datetime
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.files import File
@@ -15,13 +14,13 @@ from licenses.models import default_category
 from ok_tools.testing import DOMAIN
 from ok_tools.testing import EMAIL
 from ok_tools.testing import PWD
+from ok_tools.testing import TZ
 from ok_tools.testing import _open
 from ok_tools.testing import create_contribution
 from ok_tools.testing import create_disaimport
 from ok_tools.testing import create_license_request
 from ok_tools.testing import create_user
 from unittest.mock import patch
-from zoneinfo import ZoneInfo
 import pytest
 
 
@@ -72,7 +71,7 @@ def test__contributions__view__ListContributionsView__1(
     con1 = create_contribution(license_request, contribution_dict)
 
     contribution_dict['broadcast_date'] = datetime(
-        year=2022, month=9, day=12, hour=12)
+        year=2022, month=9, day=12, hour=12, tzinfo=TZ)
     con2 = create_contribution(license_request, contribution_dict)
 
     browser.login()
@@ -112,7 +111,7 @@ def test__contributions__admin__ContributionsAdmin__4(
         month=9,
         day=12,
         hour=8,
-        tzinfo=ZoneInfo(settings.TIME_ZONE),
+        tzinfo=TZ,
     )
     early_contr = create_contribution(license_request, contribution_dict)
 
@@ -121,7 +120,7 @@ def test__contributions__admin__ContributionsAdmin__4(
         month=9,
         day=12,
         hour=18,
-        tzinfo=ZoneInfo(settings.TIME_ZONE),
+        tzinfo=TZ,
     )
     late_contr = create_contribution(license_request, contribution_dict)
 
@@ -141,7 +140,7 @@ def test__contributions__models__1(db, license_request, contribution_dict):
         month=9,
         day=12,
         hour=8,
-        tzinfo=ZoneInfo(settings.TIME_ZONE),
+        tzinfo=TZ,
     )
     early_contr = create_contribution(license_request, contribution_dict)
 
@@ -150,7 +149,7 @@ def test__contributions__models__1(db, license_request, contribution_dict):
         month=9,
         day=12,
         hour=18,
-        tzinfo=ZoneInfo(settings.TIME_ZONE),
+        tzinfo=TZ,
     )
     late_contr = create_contribution(license_request, contribution_dict)
 
@@ -267,9 +266,9 @@ def test__contributions__disa_import__6(db, license_request):
 
     contributions = Contribution.objects.filter().order_by('broadcast_date')
     assert (contributions[0].broadcast_date ==
-            datetime(2022, 9, 8, 9, 30, tzinfo=ZoneInfo(settings.TIME_ZONE)))
+            datetime(2022, 9, 8, 9, 30, tzinfo=TZ))
     assert (contributions[1].broadcast_date ==
-            datetime(2022, 9, 8, 10, 30, tzinfo=ZoneInfo(settings.TIME_ZONE)))
+            datetime(2022, 9, 8, 10, 30, tzinfo=TZ))
 
 
 def test__contributions__admin__1(browser, db, license_request):
@@ -311,7 +310,7 @@ def test__contributions__admin__YearFilter__1(
         user.profile, default_category(), license_template_dict)
 
     contribution_dict['broadcast_date'] = datetime(
-        day=8, month=9, year=datetime.now().year)
+        day=8, month=9, year=datetime.now().year, tzinfo=TZ)
     contr1 = create_contribution(lr1, contribution_dict)
 
     license_template_dict['title'] = 'old_title'
@@ -319,7 +318,7 @@ def test__contributions__admin__YearFilter__1(
         user.profile, default_category(), license_template_dict)
 
     contribution_dict['broadcast_date'] = datetime(
-        day=8, month=9, year=datetime.now().year-1)
+        day=8, month=9, year=datetime.now().year-1, tzinfo=TZ)
     contr2 = create_contribution(lr2, contribution_dict)
 
     browser.login_admin()
@@ -351,7 +350,7 @@ def test__contributions__admin__ContributionResource__1(
         month=9,
         day=20,
         hour=9,
-        tzinfo=ZoneInfo(settings.TIME_ZONE)
+        tzinfo=TZ,
     )
     contr1 = create_contribution(license_request, contribution_dict)
 
@@ -360,7 +359,7 @@ def test__contributions__admin__ContributionResource__1(
         month=9,
         day=21,
         hour=18,
-        tzinfo=ZoneInfo(settings.TIME_ZONE)
+        tzinfo=TZ,
     )
     contr2 = create_contribution(license_request, contribution_dict)
 

--- a/contributions/disa_import.py
+++ b/contributions/disa_import.py
@@ -168,6 +168,6 @@ def disa_import(request, file):
         )
 
         if not contr_created:
-            logger.warn(f'Contribution for license {nr} already exists.')
+            logger.warning(f'Contribution for license {nr} already exists.')
         else:
             logger.info(f'Contribution {contr} created.')

--- a/licenses/licenses_tests.py
+++ b/licenses/licenses_tests.py
@@ -9,6 +9,7 @@ from django.urls import reverse_lazy
 from ok_tools.testing import DOMAIN
 from ok_tools.testing import EMAIL
 from ok_tools.testing import PWD
+from ok_tools.testing import TZ
 from ok_tools.testing import create_license_request
 from ok_tools.testing import create_user
 from ok_tools.testing import pdfToText
@@ -632,7 +633,7 @@ def test__licenses__admin__DurationFilter__1():
 def test__licenses__admin__YearFilter__1(browser, user, license_template_dict):
     """Licenses can be filtered by the year of its creation date."""
     created_at = datetime.datetime(
-        day=8, month=9, year=datetime.datetime.now().year)
+        day=8, month=9, year=datetime.datetime.now().year, tzinfo=TZ)
     license_template_dict['title'] = 'new_title'
     lr1 = create_license_request(
         user.profile, default_category(), license_template_dict)
@@ -640,7 +641,7 @@ def test__licenses__admin__YearFilter__1(browser, user, license_template_dict):
     lr1.save()
 
     created_at = datetime.datetime(
-        day=8, month=9, year=(datetime.datetime.now().year-1))
+        day=8, month=9, year=(datetime.datetime.now().year-1), tzinfo=TZ)
     license_template_dict['title'] = 'old_title'
     lr2 = create_license_request(
         user.profile, default_category(), license_template_dict)

--- a/ok_tools/settings.py
+++ b/ok_tools/settings.py
@@ -34,8 +34,8 @@ if 'OKTOOLS_CONFIG_FILE' in os.environ:
         os.environ.get('OKTOOLS_CONFIG_FILE'), encoding='utf-8'
     ))
 else:
-    logger.warning("No config file found for ok-tools."
-                   " Switching to fallbacks.")
+    logger.warninging("No config file found for ok-tools."
+                      " Switching to fallbacks.")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config.get('django', 'secret_key', fallback=None)

--- a/ok_tools/settings.py
+++ b/ok_tools/settings.py
@@ -34,8 +34,8 @@ if 'OKTOOLS_CONFIG_FILE' in os.environ:
         os.environ.get('OKTOOLS_CONFIG_FILE'), encoding='utf-8'
     ))
 else:
-    logger.warninging("No config file found for ok-tools."
-                      " Switching to fallbacks.")
+    logger.warning("No config file found for ok-tools."
+                   " Switching to fallbacks.")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config.get('django', 'secret_key', fallback=None)

--- a/ok_tools/testing.py
+++ b/ok_tools/testing.py
@@ -8,6 +8,7 @@ from licenses.models import LicenseRequest
 from projects.models import MediaEducationSupervisor
 from projects.models import Project
 from registration.models import Profile
+from zoneinfo import ZoneInfo
 import PyPDF2
 import io
 
@@ -20,6 +21,7 @@ User = get_user_model()
 EMAIL = "user@example.com"
 PWD = 'testpassword'
 DOMAIN = 'http://localhost:8000'
+TZ = ZoneInfo(settings.TIME_ZONE)
 
 
 def pdfToText(pdf) -> str:

--- a/projects/project_tests.py
+++ b/projects/project_tests.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from django import forms
 from django.urls import reverse_lazy
 from ok_tools.testing import DOMAIN
+from ok_tools.testing import TZ
 from ok_tools.testing import create_project
 from unittest.mock import patch
 import pytest
@@ -66,12 +67,12 @@ def test__projects__admin__YearFilter__1(browser, project_dict):
     """Projects can be filtered by the year of the start date."""
     project_dict['title'] = 'new_title'
     project_dict['begin_date'] = datetime(
-        year=datetime.now().year, month=9, day=20, hour=9)
+        year=datetime.now().year, month=9, day=20, hour=9, tzinfo=TZ)
     proj1 = create_project(project_dict)
 
     project_dict['title'] = 'old_title'
     project_dict['begin_date'] = datetime(
-        year=datetime.now().year-1, month=9, day=20, hour=9)
+        year=datetime.now().year-1, month=9, day=20, hour=9, tzinfo=TZ)
     proj2 = create_project(project_dict)
 
     browser.login_admin()

--- a/scripts/import_legacy.py
+++ b/scripts/import_legacy.py
@@ -168,7 +168,7 @@ def import_users(ws: Worksheet) -> IdNumberMap:
         m = _get_bool(row[M])
         w = _get_bool(row[W])
         if not (m != w):
-            logger.warn(
+            logger.warning(
                 f'Could not determine gender from user {row[NR].value}')
             return "none"
         if w:
@@ -255,8 +255,8 @@ def import_users(ws: Worksheet) -> IdNumberMap:
 
         if not created:
             # user without email but same properties already exists
-            logger.warn(f'Profile for {obj} from user number {row[NR].value}'
-                        ' already exists.')
+            logger.warning(f'Profile for {obj} from user number '
+                           f'{row[NR].value} already exists.')
 
         ids.add(row[NR].value, obj.id)
         if switched:
@@ -268,7 +268,7 @@ def import_users(ws: Worksheet) -> IdNumberMap:
         if len(list := Profile.objects.filter(
                 first_name=row[FIRST_NAME], last_name=row[LAST_NAME])) > 1:
             msg = f'Found two similar profiles for {list[0]}'
-            logger.warn(msg)
+            logger.warning(msg)
             raise NotImplementedError(msg)
 
     return ids
@@ -379,7 +379,7 @@ def import_primary_contributions(
 
         try:
             LicenseRequest.objects.get(number=row[NR].value)
-            logger.warn('Number already taken.')
+            logger.warning('Number already taken.')
             continue
         except LicenseRequest.DoesNotExist:
             pass
@@ -398,7 +398,7 @@ def import_primary_contributions(
         )
 
         if not lr_created:
-            logger.warn(f'License {lr} already exists.')
+            logger.warning(f'License {lr} already exists.')
 
         contrib, contrib_created = Contribution.objects.get_or_create(
             license=lr,
@@ -407,7 +407,7 @@ def import_primary_contributions(
         )
 
         if not lr_created and not contrib_created:
-            logger.warn(f'Contribution {contrib} already exists.')
+            logger.warning(f'Contribution {contrib} already exists.')
         elif lr_created and not contrib_created:
             logger.error(f'Only expected primary contributions. {contrib} is a'
                          'repetition.')
@@ -509,11 +509,11 @@ def import_projects(ws: Worksheet):
 
         duration = _get_duration(row[DURATION])
         if not duration:
-            logger.warn(f'Now duration for project "{row[TITLE].value}"')
+            logger.warning(f'Now duration for project "{row[TITLE].value}"')
 
         begin_date = _get_datetime(row[DAY])
         if not begin_date:
-            logger.warn(f'No begin_date for project "{row[TITLE].value}')
+            logger.warning(f'No begin_date for project "{row[TITLE].value}')
 
         try:
             project, project_created = Project.objects.get_or_create(
@@ -543,7 +543,7 @@ def import_projects(ws: Worksheet):
             raise
 
         if project_created:
-            logger.warn(f'Project "{row[TITLE].value}" already exists.')
+            logger.warning(f'Project "{row[TITLE].value}" already exists.')
         else:
             for s in me_supervisors:
                 project.media_education_supervisors.add(s.id)
@@ -611,7 +611,7 @@ def import_repetitions(
             else:
                 logger.error('No primary contribution found.')
 
-            logger.warn(f'Creating a new License for {row[NR].value}.')
+            logger.warning(f'Creating a new License for {row[NR].value}.')
 
             profile = _get_profile(row[USER_NR], user_ids)
             if not profile:
@@ -633,7 +633,7 @@ def import_repetitions(
             )
 
             if not lr_created:
-                logger.warn(f'License {license} already exists.')
+                logger.warning(f'License {license} already exists.')
 
             no_prim_found += 1
 
@@ -658,7 +658,7 @@ def import_repetitions(
         )
 
         if contr_created:
-            logger.warn(f'Repetition {contr} already exists.')
+            logger.warning(f'Repetition {contr} already exists.')
 
     if no_prim_found:
         logger.critical('Could not find primary contribution'
@@ -704,13 +704,13 @@ def _get_category(cell: Cell, category_ids: dict) -> tuple[Category, bool]:
     DEFAULT_CATEGORY_NAME = f'unbekannt_{category_nr}'
 
     if not category_nr:
-        logger.warn(f'Invalid category number {cell.value}')
+        logger.warning(f'Invalid category number {cell.value}')
         return (Category.objects.get_or_create(name=DEFAULT_CATEGORY_NAME)[0],
                 True)
 
     id = category_ids.get(cell.value)
     if not id:
-        logger.warn(f'Invalid category number {cell.value}.')
+        logger.warning(f'Invalid category number {cell.value}.')
         return (Category.objects.get_or_create(name=DEFAULT_CATEGORY_NAME)[0],
                 True)
 
@@ -727,7 +727,7 @@ def _get_category(cell: Cell, category_ids: dict) -> tuple[Category, bool]:
 def _get_time(time_c: Cell) -> datetime.time:
     """Return a datetime.time element and None if an error occurs."""
     if not time_c.value:
-        logger.warn('No time found.')
+        logger.warning('No time found.')
         return None
 
     if not time_c.is_date:
@@ -754,7 +754,7 @@ def _get_datetime(cell: Cell) -> datetime.datetime:
         return aware_datetime
     else:
         if cell.value:
-            logger.warn(f'Could not format date {cell.value}')
+            logger.warning(f'Could not format date {cell.value}')
 
         return None
 
@@ -777,11 +777,12 @@ def _get_bool(cell: Cell) -> bool:
             elif cell.value == '=FALSE()':
                 return False
             else:
-                logger.warn(f'Could not covert formula {cell.value} to bool.')
+                logger.warning(
+                    f'Could not covert formula {cell.value} to bool.')
                 return None
         case _:
-            logger.warn(f'Could not convert "{cell.value}" with type'
-                        f'{cell.data_type} to bool ')
+            logger.warning(f'Could not convert "{cell.value}" with type'
+                           f'{cell.data_type} to bool ')
             return None
 
 


### PR DESCRIPTION
Make all datetime objects time zone aware and substitute `logger.warn` with `logger.warning` due to deprecation.